### PR TITLE
ci: add automatic documentation hosting

### DIFF
--- a/.github/workflows/docs-publish.yml
+++ b/.github/workflows/docs-publish.yml
@@ -1,0 +1,27 @@
+name: Publish Documentation to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: 3.x
+          cache: 'pip'
+
+      - name: Install dependencies
+        run: pip install ".[dev]"
+
+      - name: Install mkdocs
+        run: pip install mkdocs mkdocs-material mkdocs-jupyter
+
+      - run: mkdocs gh-deploy --force


### PR DESCRIPTION
# Description

Add automatic documentation hosting using MkDocs and GitHub Pages. Documentation will be automatically updated when pushed to main branch.

# Type of change

- **ci**: Changes to CI configuration files

# Features

- Added GitHub Actions workflow
- Automatic Jupyter notebook conversion and publishing
- Automatic deployment to GitHub Pages

# Remarks

- No breaking changes